### PR TITLE
fix(jenkinsfile): npm commands need npm_token credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,11 @@ ansiColor('xterm') {
 
           stage('install') {
             image.inside(DOCKER_RUN_OPTS) {
-              sh 'npm install'
+              withCredentials([
+                string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')
+              ]) {
+                sh 'npm install'
+              }
             }
           }
 


### PR DESCRIPTION
add withCredentials blocks to each stage with npm commands passing in the NPM_TOKEN variable